### PR TITLE
rg-bot and rg-ctf-utils version update

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,43 +2,14 @@ import { RGBot } from "rg-bot";
 
 /**
  * This strategy is the simplest example of how to get started with the rg-bot package.
- * The Bot will run around and gather Poppies until it has 100 in its inventory.
  */
 export function configureBot(bot: RGBot) {
 
     bot.setDebug(true);
 
-    // This is our main loop. The Bot will invoke this on spawn.
-    // goal: collect 100 Poppies
-    async function startGathering() {
-
-        // Check the Bot's inventory - if it has less than 100 Poppies
-        // then it needs to find and gather one
-        while (bot.getInventoryItemQuantity('Poppy') < 100) {
-
-            // Try to locate a Poppy nearby and dig it up
-            const collectedPoppy = await bot.findAndDigBlock('Poppy');
-
-            if (collectedPoppy) {
-                // If the Bot collected a Poppy, then announce it in chat
-                bot.chat('I collected a Poppy.');
-            }
-            else {
-                // If the Bot couldn't find a poppy
-                // or failed to collect one that it did find,
-                // then have it wander around before trying to find another
-                await bot.wander();
-            }
-        }
-
-        // once the Bot has 4 poppies, celebrate!
-        bot.chat('Wow! I have collected 100 Poppies!');
-    }
-
-    // Have the Bot begin our main loop when it spawns into the game
+    // The bot says a message when spawning
     bot.on('spawn', async () => {
         bot.chat('Hello, I have arrived!');
-        startGathering();
     });
 
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bot-template",
   "version": "1.0.0",
-  "description": "A simple example for getting started with the rg-bot package with typescript.",
+  "description": "A simple example for getting started with the rg-bot package with Typescript.",
   "main": "index.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -10,16 +10,17 @@
   "author": "Regression Games, Inc",
   "license": "ISC",
   "dependencies": {
-    "@types/node": "^18.0.6",
-    "minecraft-data": "^3.17.0",
-    "mineflayer": "^4.5.1",
-    "mineflayer-pathfinder": "^2.4.0",
-    "node-fetch": "^3.2.6",
-    "prismarine-entity": "^2.1.1",
-    "prismarine-item": "^1.11.5",
-    "prismarine-viewer": "^1.23.0",
-    "rg-bot": "^1.3.0",
-    "rg-match-info": "^1.0.0",
-    "vec3": "^0.1.7"
+    "@types/node": "18.0.6",
+    "minecraft-data": "3.17.0",
+    "mineflayer": "4.5.1",
+    "mineflayer-pathfinder": "2.4.0",
+    "node-fetch": "3.2.6",
+    "prismarine-entity": "2.1.1",
+    "prismarine-item": "1.11.5",
+    "prismarine-viewer": "1.23.0",
+    "rg-bot": "1.6.0",
+    "rg-ctf-utils": "1.0.2",
+    "rg-match-info": "1.1.0",
+    "vec3": "0.1.7"
   }
 }


### PR DESCRIPTION
Updates this template to use the newest version of our libs, as well as updates the sample to be much simpler for getting started, especially now that UC will likely be the less-played mode.

Note that I did include rg-ctf-utils - I understand the reasons why we would not want to do that, but I figured this would be one less point of friction for this tournament.

Once this is approved, I'll make similar updates for the Javascript and Python templates.